### PR TITLE
Add static profile dashboard page

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Profile Dashboard</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="dashboard">
+    <header class="header">
+      <div class="avatar-container">
+        <img id="avatar" class="avatar" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGP4/AAAABQBAzEJ+wAAAABJRU5ErkJggg==" alt="Avatar" />
+        <input id="avatarInput" type="file" accept="image/*" hidden />
+      </div>
+      <h1>User Name</h1>
+    </header>
+    <nav class="sidebar">
+      <ul>
+        <li data-section="profile" class="active">Profile</li>
+        <li data-section="billing">Billing</li>
+        <li data-section="notifications">Notifications</li>
+        <li data-section="security">Security</li>
+      </ul>
+    </nav>
+    <main class="content">
+      <section id="profile" class="section active">
+        <h2>Profile</h2>
+        <p>Update your personal information.</p>
+      </section>
+      <section id="billing" class="section">
+        <h2>Billing</h2>
+        <p>Manage your billing details.</p>
+      </section>
+      <section id="notifications" class="section">
+        <h2>Notifications</h2>
+        <p>Configure notification preferences.</p>
+      </section>
+      <section id="security" class="section">
+        <h2>Security</h2>
+        <p>Update your password and 2FA.</p>
+      </section>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,29 @@
+const avatar = document.getElementById('avatar');
+const avatarInput = document.getElementById('avatarInput');
+
+avatar.addEventListener('click', () => avatarInput.click());
+
+avatarInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      avatar.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+
+const sections = document.querySelectorAll('.section');
+const navItems = document.querySelectorAll('.sidebar li');
+
+navItems.forEach((item) => {
+  item.addEventListener('click', () => {
+    navItems.forEach((i) => i.classList.remove('active'));
+    item.classList.add('active');
+    const id = item.getAttribute('data-section');
+    sections.forEach((sec) => {
+      sec.classList.toggle('active', sec.id === id);
+    });
+  });
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,58 @@
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+.dashboard {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+  min-height: 100vh;
+}
+.header {
+  grid-column: span 2;
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  background-color: #f5f5f5;
+}
+.avatar-container {
+  margin-right: 1rem;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+.avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  object-fit: cover;
+  cursor: pointer;
+}
+.sidebar {
+  background-color: #fafafa;
+  border-right: 1px solid #ddd;
+  padding-top: 1rem;
+}
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+.sidebar li {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+.sidebar li.active {
+  background-color: #eee;
+  font-weight: bold;
+}
+.content {
+  padding: 1rem 2rem;
+}
+.section {
+  display: none;
+  border-radius: 4px;
+}
+.section.active {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add static Profile Dashboard with Profile/Billing/Notifications/Security sections
- make layout full width and add sidebar navigation
- implement avatar upload by clicking the avatar image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686642f341948330be9567a2a26df5bf